### PR TITLE
Fix: replace deprecated model repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The `mlora.py` code is a starting point for finetuning on various datasets.
 Basic command for finetuning a baseline model on the [Alpaca Cleaned](https://github.com/gururise/AlpacaDataCleaned) dataset:
 ```bash
 python mlora.py \
-  --base_model decapoda-research/llama-7b-hf \
+  --base_model yahma/llama-7b-hf \
   --config ./config/alpaca.json \
   --load_8bit
 ```


### PR DESCRIPTION
decapoda-research/llama-7b-hf is not long included in Huggingface.