### PR TITLE
Add BF16 and FP16 Support

### DIFF
--- a/.github/workflows/run_on_dev.yml
+++ b/.github/workflows/run_on_dev.yml
@@ -96,4 +96,9 @@ jobs:
       - name: finetune llama-7b with mixlora
         run: |
           cd /workspace/multi-lora-fine-tune
-          python mlora.py --base_model /data/llama-7b-hf --config ./config/finetune_mixlora.json --load_8bit
+          python mlora.py --base_model /data/llama-7b-hf --config ./config/dummy_mixlora.json --load_8bit
+      
+      - name: test inference with lora
+        run: |
+          cd /workspace/multi-lora-fine-tune
+          python generate.py --base_model "/data/llama-7b-hf" --lora_weights "./lora_0" --half_precision --instruction "What is m-LoRA?"

--- a/.github/workflows/run_on_dev.yml
+++ b/.github/workflows/run_on_dev.yml
@@ -101,4 +101,4 @@ jobs:
       - name: test inference with lora
         run: |
           cd /workspace/multi-lora-fine-tune
-          python generate.py --base_model "/data/llama-7b-hf" --lora_weights "./lora_0" --half_precision --instruction "What is m-LoRA?"
+          python generate.py --base_model "/data/llama-7b-hf" --lora_weights "./lora_0" --load_16bit --instruction "What is m-LoRA?"

--- a/config/alpaca.json
+++ b/config/alpaca.json
@@ -34,7 +34,7 @@
         },
         {
             "name": "lora_1",
-            "output": "lora_1",
+            "optim": "adamw",
             "lr": 3e-4,
             "batch_size": 16,
             "micro_batch_size": 4,

--- a/generate.py
+++ b/generate.py
@@ -16,7 +16,7 @@ def main(base_model: str,
     model = mlora.LlamaModel.from_pretrained(base_model, device=device,
                                              bits=(8 if load_8bit else (
                                                  4 if load_4bit else None)),
-                                             dtype=torch.bfloat16 if load_16bit else torch.float32)
+                                             load_dtype=torch.bfloat16 if load_16bit else torch.float32)
     tokenizer = mlora.Tokenizer(base_model)
 
     if lora_weights:

--- a/generate.py
+++ b/generate.py
@@ -8,7 +8,7 @@ def main(base_model: str,
          input: str = None,
          template: str = None,
          lora_weights: str = None,
-         half_precision: bool = False,
+         load_16bit: bool = False,
          load_8bit: bool = False,
          load_4bit: bool = False,
          device: str = "cuda:0"):
@@ -16,7 +16,7 @@ def main(base_model: str,
     model = mlora.LlamaModel.from_pretrained(base_model, device=device,
                                              bits=(8 if load_8bit else (
                                                  4 if load_4bit else None)),
-                                             dtype=torch.bfloat16 if half_precision else torch.float32)
+                                             dtype=torch.bfloat16 if load_16bit else torch.float32)
     tokenizer = mlora.Tokenizer(base_model)
 
     if lora_weights:

--- a/generate.py
+++ b/generate.py
@@ -1,4 +1,5 @@
 import mlora
+import torch
 import fire
 
 
@@ -7,12 +8,15 @@ def main(base_model: str,
          input: str = None,
          template: str = None,
          lora_weights: str = None,
+         half_precision: bool = False,
          load_8bit: bool = False,
          load_4bit: bool = False,
          device: str = "cuda:0"):
 
     model = mlora.LlamaModel.from_pretrained(base_model, device=device,
-                                             bits=(8 if load_8bit else (4 if load_4bit else None)))
+                                             bits=(8 if load_8bit else (
+                                                 4 if load_4bit else None)),
+                                             dtype=torch.bfloat16 if half_precision else torch.float32)
     tokenizer = mlora.Tokenizer(base_model)
 
     if lora_weights:

--- a/inference.py
+++ b/inference.py
@@ -74,7 +74,7 @@ def main(base_model: str,
     model = mlora.LlamaModel.from_pretrained(base_model, device=device,
                                              bits=(8 if load_8bit else (
                                                  4 if load_4bit else None)),
-                                             dtype=torch.bfloat16 if load_16bit else torch.float32)
+                                             load_dtype=torch.bfloat16 if load_16bit else torch.float32)
     tokenizer = mlora.Tokenizer(base_model)
 
     if lora_weights:

--- a/inference.py
+++ b/inference.py
@@ -1,5 +1,6 @@
 import fire
 import mlora
+import torch
 import traceback
 import gradio as gr
 
@@ -63,6 +64,7 @@ class Iteratorize:
 def main(base_model: str,
          template: str = None,
          lora_weights: str = "",
+         half_precision: bool = False,
          load_8bit: bool = False,
          load_4bit: bool = False,
          device: str = "cuda:0",
@@ -70,7 +72,9 @@ def main(base_model: str,
          share_gradio: bool = False):
 
     model = mlora.LlamaModel.from_pretrained(base_model, device=device,
-                                             bits=(8 if load_8bit else (4 if load_4bit else None)))
+                                             bits=(8 if load_8bit else (
+                                                 4 if load_4bit else None)),
+                                             dtype=torch.bfloat16 if half_precision else torch.float32)
     tokenizer = mlora.Tokenizer(base_model)
 
     if lora_weights:

--- a/inference.py
+++ b/inference.py
@@ -64,7 +64,7 @@ class Iteratorize:
 def main(base_model: str,
          template: str = None,
          lora_weights: str = "",
-         half_precision: bool = False,
+         load_16bit: bool = False,
          load_8bit: bool = False,
          load_4bit: bool = False,
          device: str = "cuda:0",
@@ -74,7 +74,7 @@ def main(base_model: str,
     model = mlora.LlamaModel.from_pretrained(base_model, device=device,
                                              bits=(8 if load_8bit else (
                                                  4 if load_4bit else None)),
-                                             dtype=torch.bfloat16 if half_precision else torch.float32)
+                                             dtype=torch.bfloat16 if load_16bit else torch.float32)
     tokenizer = mlora.Tokenizer(base_model)
 
     if lora_weights:

--- a/mlora.py
+++ b/mlora.py
@@ -84,7 +84,8 @@ def load_base_model() -> Tuple[mlora.Tokenizer, mlora.LLMModel]:
         model = mlora.ChatGLMModel.from_pretrained(
             path=args.base_model,
             device=args.device,
-            bits=(8 if args.load_8bit else (4 if args.load_4bit else None))
+            bits=(8 if args.load_8bit else (4 if args.load_4bit else None)),
+            dtype=torch.float32
         )
     else:
         raise f"unkown model type {args.model_type}"

--- a/mlora.py
+++ b/mlora.py
@@ -41,6 +41,8 @@ parser.add_argument('--disable_adapter', action="store_true",
                     help="Disable the adapter modules")
 parser.add_argument('--tokenizer', type=str,
                     help='Path to or name of tokenizer')
+parser.add_argument('--half_precision', action='store_true',
+                    help='Load model in half precision')
 parser.add_argument('--load_8bit', action="store_true",
                     help='Load model in 8bit mode')
 parser.add_argument('--load_4bit', action="store_true",
@@ -74,7 +76,8 @@ def load_base_model() -> Tuple[mlora.Tokenizer, mlora.LLMModel]:
         model = mlora.LlamaModel.from_pretrained(
             path=args.base_model,
             device=args.device,
-            bits=(8 if args.load_8bit else (4 if args.load_4bit else None))
+            bits=(8 if args.load_8bit else (4 if args.load_4bit else None)),
+            dtype=torch.bfloat16 if args.half_precision else torch.float32
         )
     elif args.model_type == "chatglm":
         logging.info("Initializing ChatGLM model.")

--- a/mlora.py
+++ b/mlora.py
@@ -77,7 +77,7 @@ def load_base_model() -> Tuple[mlora.Tokenizer, mlora.LLMModel]:
             path=args.base_model,
             device=args.device,
             bits=(8 if args.load_8bit else (4 if args.load_4bit else None)),
-            dtype=torch.bfloat16 if args.load_16bit else torch.float32
+            load_dtype=torch.bfloat16 if args.load_16bit else torch.float32
         )
     elif args.model_type == "chatglm":
         logging.info("Initializing ChatGLM model.")
@@ -85,7 +85,7 @@ def load_base_model() -> Tuple[mlora.Tokenizer, mlora.LLMModel]:
             path=args.base_model,
             device=args.device,
             bits=(8 if args.load_8bit else (4 if args.load_4bit else None)),
-            dtype=torch.float32
+            load_dtype=torch.float32
         )
     else:
         raise f"unkown model type {args.model_type}"

--- a/mlora.py
+++ b/mlora.py
@@ -41,7 +41,7 @@ parser.add_argument('--disable_adapter', action="store_true",
                     help="Disable the adapter modules")
 parser.add_argument('--tokenizer', type=str,
                     help='Path to or name of tokenizer')
-parser.add_argument('--half_precision', action='store_true',
+parser.add_argument('--load_16bit', action='store_true',
                     help='Load model in half precision')
 parser.add_argument('--load_8bit', action="store_true",
                     help='Load model in 8bit mode')
@@ -77,7 +77,7 @@ def load_base_model() -> Tuple[mlora.Tokenizer, mlora.LLMModel]:
             path=args.base_model,
             device=args.device,
             bits=(8 if args.load_8bit else (4 if args.load_4bit else None)),
-            dtype=torch.bfloat16 if args.half_precision else torch.float32
+            dtype=torch.bfloat16 if args.load_16bit else torch.float32
         )
     elif args.model_type == "chatglm":
         logging.info("Initializing ChatGLM model.")

--- a/mlora/lora_liner.py
+++ b/mlora/lora_liner.py
@@ -29,11 +29,11 @@ class Lora(torch.nn.Module):
         self.scaling_ = alpha / r
 
     def forward(self, data: torch.Tensor) -> torch.Tensor:
-        data_ = F.dropout(data, self.dropout_)
+        data_ = F.dropout(data.type_as(self.lora_a_), self.dropout_)
         data_ @= self.lora_a_.transpose(0, 1)
         data_ @= self.lora_b_.transpose(0, 1)
         data_ *= self.scaling_
-        return data_
+        return data_.type_as(data)
 
 
 class Linear(torch.nn.Module):
@@ -46,10 +46,8 @@ class Linear(torch.nn.Module):
             self.device_ = device
 
         if not isinstance(weight, torch.nn.Linear):
-            import bitsandbytes
-            assert isinstance(weight,
-                              bitsandbytes.nn.Linear8bitLt) or isinstance(weight,
-                                                                          bitsandbytes.nn.Linear4bit), "error type."
+            assert isinstance(weight, bitsandbytes.nn.Linear8bitLt) or isinstance(
+                weight, bitsandbytes.nn.Linear4bit), "error type."
         else:
             weight.requires_grad_(False)
 

--- a/mlora/lora_liner.py
+++ b/mlora/lora_liner.py
@@ -29,11 +29,11 @@ class Lora(torch.nn.Module):
         self.scaling_ = alpha / r
 
     def forward(self, data: torch.Tensor) -> torch.Tensor:
-        data_ = F.dropout(data.type_as(self.lora_a_), self.dropout_)
+        data_ = F.dropout(data.to(self.lora_a_.dtype), self.dropout_)
         data_ @= self.lora_a_.transpose(0, 1)
         data_ @= self.lora_b_.transpose(0, 1)
         data_ *= self.scaling_
-        return data_.type_as(data)
+        return data_.to(data.dtype)
 
 
 class Linear(torch.nn.Module):

--- a/mlora/model.py
+++ b/mlora/model.py
@@ -70,7 +70,8 @@ def repeat_kv(x: torch.Tensor, n_rep: int) -> torch.Tensor:
 
 
 def apply_rotary_emb(xq: torch.Tensor, xk: torch.Tensor,
-                     angle: Tuple[torch.Tensor, torch.Tensor]) -> Tuple[torch.Tensor, torch.Tensor]:
+                     angle: Tuple[torch.Tensor, torch.Tensor],
+                     dtype: torch.dtype) -> Tuple[torch.Tensor, torch.Tensor]:
     # data shape is: batch_size * max_seq_len * n_head * n_dim
     _, max_seq_len, _, dim_head = xq.shape
 
@@ -79,7 +80,7 @@ def apply_rotary_emb(xq: torch.Tensor, xk: torch.Tensor,
 
     xq = (xq * cos) + (rotate_half(xq) * sin)
     xk = (xk * cos) + (rotate_half(xk) * sin)
-    return (xq, xk)
+    return (xq.to(dtype), xk.to(dtype))
 
 
 def apply_rotary_emb_to_one(x: torch.Tensor, angle: Tuple[torch.Tensor, torch.Tensor]) -> torch.Tensor:

--- a/mlora/model_chatglm.py
+++ b/mlora/model_chatglm.py
@@ -9,7 +9,7 @@ import torch
 import torch.nn.functional as F
 import xformers.ops
 import xformers.ops.fmha.attn_bias
-from transformers import AutoModel
+from transformers import AutoModel, BitsAndBytesConfig
 from typing import List, Dict, Optional, Tuple
 from huggingface_hub import snapshot_download
 import os
@@ -184,17 +184,32 @@ class ChatGLMModel(LLMModel):
     def from_pretrained(path: str,
                         device: str,
                         bits: int = None,
-                        fp16: bool = True,
-                        bf16: bool = True,
+                        dtype: torch.dtype = torch.bfloat16,
+                        compute_dtype: torch.dtype = torch.bfloat16,
                         double_quant: bool = True,
                         quant_type: str = 'nf4',
                         ) -> LLMModel:
+        if dtype not in [torch.bfloat16, torch.float16, torch.float32]:
+            raise ValueError(f"unsupported dtype {dtype}")
+
+        if compute_dtype not in [torch.bfloat16, torch.float16, torch.float32]:
+            raise ValueError(f"unsupported compute dtype {dtype}")
+
+        if dtype in [torch.bfloat16, torch.float16]:
+            logging.info(f"Loading model with half precision.")
+
+        if not torch.cuda.is_bf16_supported():
+            if dtype == torch.bfloat16:
+                logging.warning("bf16 is not available. deprecated to fp16.")
+                dtype = torch.float16
+
+            if compute_dtype == torch.bfloat16:
+                logging.warning("bf16 is not available. deprecated to fp16.")
+                compute_dtype = torch.float16
+
         # now only support the qlora - 4bit
         if bits in [4, 8]:
             logging.info(f"Loading model with quantization, bits = {bits}.")
-            from transformers import BitsAndBytesConfig
-            compute_dtype = (torch.float16 if fp16 else (
-                torch.bfloat16 if bf16 else torch.float32))
             chatglm_model = AutoModel.from_pretrained(
                 path,
                 trust_remote_code=True,
@@ -210,12 +225,12 @@ class ChatGLMModel(LLMModel):
                     bnb_4bit_use_double_quant=double_quant,
                     bnb_4bit_quant_type=quant_type,
                 ),
-                torch_dtype=(torch.float32 if fp16 else (torch.bfloat16 if bf16 else torch.float32)))
+                torch_dtype=dtype)
         else:
             chatglm_model = AutoModel.from_pretrained(
                 path,
                 device_map=device,
-                torch_dtype=torch.float32,
+                torch_dtype=dtype,
                 quantization_bit=bits,
                 trust_remote_code=True)
 

--- a/mlora/model_chatglm.py
+++ b/mlora/model_chatglm.py
@@ -184,24 +184,24 @@ class ChatGLMModel(LLMModel):
     def from_pretrained(path: str,
                         device: str,
                         bits: int = None,
-                        dtype: torch.dtype = torch.bfloat16,
+                        load_dtype: torch.dtype = torch.bfloat16,
                         compute_dtype: torch.dtype = torch.bfloat16,
                         double_quant: bool = True,
                         quant_type: str = 'nf4',
                         ) -> LLMModel:
-        if dtype not in [torch.bfloat16, torch.float16, torch.float32]:
-            raise ValueError(f"unsupported dtype {dtype}")
+        if load_dtype not in [torch.bfloat16, torch.float16, torch.float32]:
+            raise ValueError(f"unsupported dtype {load_dtype}")
 
         if compute_dtype not in [torch.bfloat16, torch.float16, torch.float32]:
-            raise ValueError(f"unsupported compute dtype {dtype}")
+            raise ValueError(f"unsupported compute dtype {compute_dtype}")
 
-        if dtype in [torch.bfloat16, torch.float16]:
+        if load_dtype in [torch.bfloat16, torch.float16]:
             logging.info("Loading model with half precision.")
 
         if not torch.cuda.is_bf16_supported():
-            if dtype == torch.bfloat16:
+            if load_dtype == torch.bfloat16:
                 logging.warning("bf16 is not available. deprecated to fp16.")
-                dtype = torch.float16
+                load_dtype = torch.float16
 
             if compute_dtype == torch.bfloat16:
                 logging.warning("bf16 is not available. deprecated to fp16.")
@@ -225,12 +225,12 @@ class ChatGLMModel(LLMModel):
                     bnb_4bit_use_double_quant=double_quant,
                     bnb_4bit_quant_type=quant_type,
                 ),
-                torch_dtype=dtype)
+                torch_dtype=load_dtype)
         else:
             chatglm_model = AutoModel.from_pretrained(
                 path,
                 device_map=device,
-                torch_dtype=dtype,
+                torch_dtype=load_dtype,
                 quantization_bit=bits,
                 trust_remote_code=True)
 

--- a/mlora/model_chatglm.py
+++ b/mlora/model_chatglm.py
@@ -196,7 +196,7 @@ class ChatGLMModel(LLMModel):
             raise ValueError(f"unsupported compute dtype {dtype}")
 
         if dtype in [torch.bfloat16, torch.float16]:
-            logging.info(f"Loading model with half precision.")
+            logging.info("Loading model with half precision.")
 
         if not torch.cuda.is_bf16_supported():
             if dtype == torch.bfloat16:

--- a/mlora/model_llama.py
+++ b/mlora/model_llama.py
@@ -15,6 +15,7 @@ import xformers.ops
 import xformers.ops.fmha.attn_bias
 from typing import List, Dict, Tuple, Optional
 from huggingface_hub import snapshot_download
+from transformers import BitsAndBytesConfig
 from transformers import LlamaForCausalLM
 from collections import OrderedDict
 import logging
@@ -42,7 +43,8 @@ class OutputLayer(torch.nn.Module):
         self.weight_: torch.Tensor = weight
 
     def forward(self, data: torch.Tensor) -> torch.Tensor:
-        return data @ self.weight_.transpose(0, 1)
+        data_ = data.to(self.weight_.dtype) @ self.weight_.transpose(0, 1)
+        return data_.type_as(data)
 
 
 class RMSNormLayer(torch.nn.Module):
@@ -81,6 +83,7 @@ class Transformer(torch.nn.Module):
         self.n_kv_heads_ = args.n_kv_heads_
         self.n_rep_ = self.n_heads_ // self.n_kv_heads_
         self.head_dim_ = args.dim_ // args.n_heads_
+        self.dtype_ = args.dtype
 
     def init_lora_layer_weight(self, config: LoraConfig, weight: Optional[Dict[str, torch.Tensor]]):
         adapter_name = config.adapter_name_
@@ -160,7 +163,7 @@ class Transformer(torch.nn.Module):
         xv = xv.view(batch_size, max_seq_len, self.n_kv_heads_, self.head_dim_)
 
         # apply rotary embedding
-        xq, xk = apply_rotary_emb(xq, xk, rope_angle)
+        xq, xk = apply_rotary_emb(xq, xk, rope_angle, self.dtype_)
 
         # apply kv cache
         if input_args.kv_cache_ is not None:
@@ -251,6 +254,7 @@ class LlamaModel(LLMModel):
         self.pad_token_id_ = args.pad_token_id_
         self.max_seq_len_ = args.max_seq_len_
         self.dim_ = args.dim_
+        self.dtype_ = args.dtype
 
         # adapter configs
         self.adapter_configs_: Dict[str, LoraConfig] = {}
@@ -276,7 +280,8 @@ class LlamaModel(LLMModel):
             data = (tokens, mask, self.rope_angle_, input, False)
         else:
             # prepare mask
-            mask = precompute_mask(input, self.n_heads_, self.device_)
+            mask = precompute_mask(input, self.n_heads_,
+                                   self.device_).to(self.dtype_)
             # store routing data when training
             if input.output_router_logits_:
                 input.router_logits_: Tuple[List] = tuple([] for _ in range(
@@ -296,16 +301,31 @@ class LlamaModel(LLMModel):
     def from_pretrained(path: str,
                         device: str,
                         bits: int = None,
-                        fp16: bool = True,
-                        bf16: bool = True,
+                        dtype: torch.dtype = torch.bfloat16,
+                        compute_dtype: torch.dtype = torch.bfloat16,
                         double_quant: bool = True,
                         quant_type: str = 'nf4',
                         ) -> LLMModel:
+        if dtype not in [torch.bfloat16, torch.float16, torch.float32]:
+            raise ValueError(f"unsupported dtype {dtype}")
+
+        if compute_dtype not in [torch.bfloat16, torch.float16, torch.float32]:
+            raise ValueError(f"unsupported compute dtype {dtype}")
+
+        if dtype in [torch.bfloat16, torch.float16]:
+            logging.info(f"Loading model with half precision.")
+
+        if not torch.cuda.is_bf16_supported():
+            if dtype == torch.bfloat16:
+                logging.warning("bf16 is not available. deprecated to fp16.")
+                dtype = torch.float16
+
+            if compute_dtype == torch.bfloat16:
+                logging.warning("bf16 is not available. deprecated to fp16.")
+                compute_dtype = torch.float16
+
         if bits in [4, 8]:
             logging.info(f"Loading model with quantization, bits = {bits}.")
-            from transformers import BitsAndBytesConfig
-            compute_dtype = (torch.float16 if fp16 else (
-                torch.bfloat16 if bf16 else torch.float32))
             llama_model = LlamaForCausalLM.from_pretrained(
                 path,
                 load_in_4bit=bits == 4,
@@ -320,12 +340,12 @@ class LlamaModel(LLMModel):
                     bnb_4bit_use_double_quant=double_quant,
                     bnb_4bit_quant_type=quant_type,
                 ),
-                torch_dtype=(torch.float32 if fp16 else (torch.bfloat16 if bf16 else torch.float32)))
+                torch_dtype=dtype)
         else:
             llama_model = LlamaForCausalLM.from_pretrained(
                 path,
                 device_map=device,
-                torch_dtype=torch.float32)
+                torch_dtype=dtype)
 
         llama_args = LLMModelArgs()
         llama_args.dim_ = llama_model.config.hidden_size
@@ -340,22 +360,23 @@ class LlamaModel(LLMModel):
         llama_args.pad_token_id_ = llama_model.config.pad_token_id
         if llama_args.pad_token_id_ is None:
             llama_args.pad_token_id_ = -1
+        llama_args.dtype = llama_model.dtype
 
         llama_args.device = device
 
         model = LlamaModel(llama_args)
 
         embedding_weight = llama_model.model.embed_tokens.weight.to(
-            device=device).requires_grad_(False)
+            device=device).detach()
         model.token_embedding_ = Embedding(
             embedding_weight, llama_args.pad_token_id_)
 
         output_weight = llama_model.lm_head.weight.to(
-            dtype=torch.float32, device=device).requires_grad_(False)
+            dtype=torch.float32, device=device).detach()
         model.output_ = OutputLayer(output_weight)
 
         norm_weight = llama_model.model.norm.weight.to(
-            device=device).requires_grad_(False)
+            device=device).detach()
         model.norm_ = RMSNormLayer(norm_weight, model.norm_eps_)
 
         for idx, layer in enumerate(llama_model.model.layers):
@@ -369,14 +390,14 @@ class LlamaModel(LLMModel):
                 layer.self_attn.o_proj, device=device)
             model.layers_[idx].ffn_ = FeedForward(
                 norm=RMSNorm(layer.post_attention_layernorm.weight.to(
-                    device=device).requires_grad_(False), model.norm_eps_),
+                    device=device).detach(), model.norm_eps_),
                 w1=Linear(layer.mlp.gate_proj, device=device),
                 w2=Linear(layer.mlp.down_proj, device=device),
                 w3=Linear(layer.mlp.up_proj, device=device),
                 device=device
             )
             model.layers_[idx].attention_norm_ = RMSNorm(
-                layer.input_layernorm.weight.to(device=device).requires_grad_(False), model.norm_eps_)
+                layer.input_layernorm.weight.to(device=device).detach(), model.norm_eps_)
 
         return model
 
@@ -466,7 +487,7 @@ class LlamaModel(LLMModel):
 
     def prepare_kv_cache(self, batch_size, max_seq_len) -> KVCache:
         return KVCache(batch_size, max_seq_len, self.n_kv_heads_,
-                       self.dim_ // self.n_heads_, len(self.layers_), self.device_)
+                       self.dim_ // self.n_heads_, len(self.layers_), self.device_, self.dtype_)
 
     def sequential_module(self) -> torch.nn.Sequential:
         seq_module = OrderedDict()

--- a/mlora/model_llama.py
+++ b/mlora/model_llama.py
@@ -313,7 +313,7 @@ class LlamaModel(LLMModel):
             raise ValueError(f"unsupported compute dtype {dtype}")
 
         if dtype in [torch.bfloat16, torch.float16]:
-            logging.info(f"Loading model with half precision.")
+            logging.info("Loading model with half precision.")
 
         if not torch.cuda.is_bf16_supported():
             if dtype == torch.bfloat16:

--- a/mlora/modelargs.py
+++ b/mlora/modelargs.py
@@ -29,6 +29,7 @@ class LLMModelArgs:
     pad_token_id_: int = -1
     max_seq_len_: int = 2048
     device: str = ""
+    dtype: torch.dtype = None
 
 
 @dataclass
@@ -40,14 +41,14 @@ class LoraBatchDataConfig:
 
 class KVCache:
     def __init__(self, max_batch_size, max_seq_len, n_local_kv_heads, head_dim,
-                 n_layers, device="cuda:0") -> None:
+                 n_layers, device="cuda:0", dtype=torch.float32) -> None:
         self.cache_k: List[torch.Tensor] = []
         self.cache_v: List[torch.Tensor] = []
         for _ in range(n_layers):
             self.cache_k.append(torch.zeros(
-                (max_batch_size, max_seq_len, n_local_kv_heads, head_dim), device=device))
+                (max_batch_size, max_seq_len, n_local_kv_heads, head_dim), device=device, dtype=dtype))
             self.cache_v.append(torch.zeros(
-                (max_batch_size, max_seq_len, n_local_kv_heads, head_dim), device=device))
+                (max_batch_size, max_seq_len, n_local_kv_heads, head_dim), device=device, dtype=dtype))
         self.seq_pos: int = 0
 
     def update(self, xk: torch.Tensor, xv: torch.Tensor, layer_idx: int,
@@ -86,6 +87,7 @@ class MultiLoraBatchData:
 class LoraConfig:
     adapter_name_: str = ""
     device_: str = "cuda:0"
+    dtype_: torch.dtype = None
     lora_r_: int = None
     lora_alpha_: int = None
     lora_dropout_: float = None


### PR DESCRIPTION
Currently, m-lora uses FP32. However, for devices with abundant video memory, you can load FP16 without using quantization to reduce the accuracy loss and overhead caused by quantization; for devices with insufficient video memory, you can further save time in the training process by using FP16 and quantization.